### PR TITLE
Stop using deprecated mongo APIs

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -286,8 +286,7 @@ releases.  Please use 'make-connection' in combination with
 (defn db-ref
   "Convenience DBRef constructor."
   [ns id]
-  (DBRef. (get-db *mongo-config*)
-          ^String (named ns)
+  (DBRef. ^String (named ns)
           ^Object id))
 
 (defn db-ref? [x]

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -228,7 +228,6 @@ releases.  Please use 'make-connection' in combination with
 
 (def write-concern-map
   {:acknowledged         WriteConcern/ACKNOWLEDGED
-   :errors-ignored       WriteConcern/ERRORS_IGNORED
    :fsynced              WriteConcern/FSYNCED
    :journaled            WriteConcern/JOURNALED
    :majority             WriteConcern/MAJORITY
@@ -237,7 +236,6 @@ releases.  Please use 'make-connection' in combination with
    ;; these are pre-2.10.x names for write concern:
    :fsync-safe    WriteConcern/FSYNC_SAFE  ;; deprecated - use :fsynced
    :journal-safe  WriteConcern/JOURNAL_SAFE ;; deprecated - use :journaled
-   :none          WriteConcern/NONE ;; deprecated - use :errors-ignored
    :normal        WriteConcern/NORMAL ;; deprecated - use :unacknowledged
    :replicas-safe WriteConcern/REPLICAS_SAFE ;; deprecated - use :replica-acknowledged
    :safe          WriteConcern/SAFE ;; deprecated - use :acknowledged

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -332,23 +332,33 @@ releases.  Please use 'make-connection' in combination with
 
 (def ^:private read-preference-map
   "Private map of facory functions of ReadPreferences to aliases."
-  {:nearest (fn nearest ([] (ReadPreference/nearest)) ([first-tag remaining-tags] (ReadPreference/nearest first-tag remaining-tags)))
-   :primary (fn primary ([] (ReadPreference/primary)) ([_ _] (throw (IllegalArgumentException. "Read preference :primary does not accept tag sets."))))
-   :primary-preferred (fn primary-preferred ([] (ReadPreference/primaryPreferred)) ([first-tag remaining-tags] (ReadPreference/primaryPreferred first-tag remaining-tags)))
-   :secondary (fn secondary ([] (ReadPreference/secondary)) ([first-tag remaining-tags] (ReadPreference/secondary first-tag remaining-tags)))
-   :secondary-preferred (fn secondary-preferred ([] (ReadPreference/secondaryPreferred)) ([first-tag remaining-tags] (ReadPreference/secondaryPreferred first-tag remaining-tags)))})
+  {:nearest (fn nearest ([] (ReadPreference/nearest)) ([tags] (ReadPreference/nearest tags)))
+   :primary (fn primary ([] (ReadPreference/primary)) ([_] (throw (IllegalArgumentException. "Read preference :primary does not accept tag sets."))))
+   :primary-preferred (fn primary-preferred ([] (ReadPreference/primaryPreferred)) ([tags] (ReadPreference/primaryPreferred tags)))
+   :secondary (fn secondary ([] (ReadPreference/secondary)) ([tags] (ReadPreference/secondary tags)))
+   :secondary-preferred (fn secondary-preferred ([] (ReadPreference/secondaryPreferred)) ([tags] (ReadPreference/secondaryPreferred tags)))})
+
+(defn named?
+  [x]
+  (instance? clojure.lang.Named x))
+
+(defn ->tagset
+  [tag]
+  (letfn [(->tag [[k v]]
+            (com.mongodb.Tag. (if (named? k) (name k) (str k))
+                              (if (named? v) (name v) (str v))))]
+    (com.mongodb.TagSet. (map ->tag tag))))
+
 
 (defn read-preference
   "Creates a ReadPreference from an alias and optional tag sets. Valid aliases are :nearest,
    :primary, :primary-preferred, :secondary and :secondary-preferred."
-  {:arglists '([preference {:first-tag "value"} {:other-tag-set "other-value"}])}
+  {:arglists '([preference {:first-tag "value", :second-tag "second-value"} {:other-tag-set "other-value"}])}
   [preference & tags]
   (if-let [pref-factory (get read-preference-map preference)]
     (if (empty? tags)
       (pref-factory)
-      (pref-factory
-        (coerce (first tags) [:clojure :mongo ])
-        (into-array com.mongodb.DBObject (coerce (rest tags) [:clojure :mongo ] :many true)))
+      (pref-factory (map ->tagset tags))
       )
     (throw (IllegalArgumentException. (str preference " is not a valid ReadPreference alias.")))))
 

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -598,7 +598,7 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
    [c f & {:keys [name unique sparse background]
            :or {name nil unique false sparse false background false}}]
    (-> (get-coll c)
-       (.ensureIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique :sparse sparse :background background}
+       (.createIndex (coerce-index-fields f) ^DBObject (coerce (merge {:unique unique :sparse sparse :background background}
                                                                        (if name {:name name}))
                                                                 [:clojure :mongo]))))
 (defn drop-index!

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -6,6 +6,7 @@
         clojure.pprint)
   (:use [clojure.data.json :only (read-str write-str)])
   (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder DuplicateKeyException
+                        Tag TagSet
             ReadPreference
             WriteConcern]))
 
@@ -847,20 +848,19 @@ function ()
 
 
 (deftest test-read-preference
-  (let [^DBObject f-tag (BasicDBObject. "location" "nearby")
-        r-tags (into-array DBObject [(BasicDBObject. "rack" "bottom")])
-        empty-tags (into-array DBObject [])]
+  (let [f-tag (TagSet. (Tag. "location" "nearby"))
+        r-tags (TagSet. (Tag. "rack" "bottom"))]
     (are [expected type tags] (= expected (apply read-preference (cons type tags)))
       (ReadPreference/nearest) :nearest nil
-      (ReadPreference/nearest f-tag empty-tags) :nearest [{:location "nearby"}]
-      (ReadPreference/nearest f-tag r-tags) :nearest [{:location "nearby"} {:rack :bottom}]
+      (ReadPreference/nearest f-tag) :nearest [{:location "nearby"}]
+      (ReadPreference/nearest [f-tag r-tags]) :nearest [{:location "nearby"} {:rack :bottom}]
       (ReadPreference/primary) :primary nil
       (ReadPreference/primaryPreferred) :primary-preferred nil
-      (ReadPreference/primaryPreferred f-tag empty-tags) :primary-preferred [{:location "nearby"}]
-      (ReadPreference/primaryPreferred f-tag r-tags) :primary-preferred [{:location "nearby"} {:rack :bottom}]
+      (ReadPreference/primaryPreferred f-tag) :primary-preferred [{:location "nearby"}]
+      (ReadPreference/primaryPreferred [f-tag r-tags]) :primary-preferred [{:location "nearby"} {:rack :bottom}]
       (ReadPreference/secondary) :secondary nil
-      (ReadPreference/secondary f-tag empty-tags) :secondary [{:location "nearby"}]
-      (ReadPreference/secondary f-tag r-tags) :secondary [{:location "nearby"} {:rack :bottom}]
+      (ReadPreference/secondary f-tag) :secondary [{:location "nearby"}]
+      (ReadPreference/secondary [f-tag r-tags]) :secondary [{:location "nearby"} {:rack :bottom}]
       (ReadPreference/secondaryPreferred) :secondary-preferred nil
       )))
 

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -5,7 +5,7 @@
         somnium.congomongo.coerce
         clojure.pprint)
   (:use [clojure.data.json :only (read-str write-str)])
-  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder MongoException$DuplicateKey
+  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder DuplicateKeyException
             ReadPreference
             WriteConcern]))
 
@@ -562,9 +562,9 @@
     (try
       (insert! :sparse-index-coll {})
       (is true)
-      (catch MongoException$DuplicateKey e
+      (catch DuplicateKeyException e
         (is false "Unable to insert second document without the sparse index key")))
-    (is (thrown? MongoException$DuplicateKey
+    (is (thrown? DuplicateKeyException
                  (insert! :sparse-index-coll {:a "foo"})))
     (set-write-concern *mongo-config* :unacknowledged)))
 


### PR DESCRIPTION
Most changes are obvious. The Tags/TagSet needs a bit more explanation.

The Mongo API used to use a generic `DBObject` which was a map-like thing. To set read-preference tags you just needed to make one of these and set some key/value pairs on it.

Mongo 2.13 deprecated the `DBObject` methods for read-preference selectors and replaced them with `TagSets`.
A `Tag` is a single key/value pair and a `TagSet` is a collection of `Tags`, i.e. `TagSet` corresponds to `DBObject`.
Unfortunately using these more specific types breaks the `coerce` fns since not everything is a `DBObject` any more. I've hacked around by adding `->tagset`.
It'd be cleaner to add this into the coercion framework, I may add that later.

I'm not that happy with the fact I also had to modify the test that tests the read-preferences fn, makes it a bit harder to be sure the change is correct.