### PR TITLE
Modify congomongo to work with a Mongo 3.0 driver

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/core.incubator "0.1.3"]
                  [org.clojure/data.json "0.2.4"]
-                 [org.mongodb/mongo-java-driver "2.13.2"]
+                 [org.mongodb/mongo-java-driver "3.0.4"]
                  [org.clojure/clojure "1.7.0"]]
   ;; if a :dev profile is added, remember to update :aliases below to
   ;; use it in each with-profile group!

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -297,7 +297,6 @@ releases.  Please use 'make-connection' in combination with
   [collection]
   (.collectionExists (get-db *mongo-config*)
                      ^String (named collection)))
-
 (defn create-collection!
   "Explicitly create a collection with the given name, which must not already exist.
 
@@ -311,10 +310,14 @@ releases.  Please use 'make-connection' in combination with
    :max    -> int: max number of documents."
   {:arglists
    '([collection :capped :size :max])}
-  ([collection & {:keys [capped size max] :as options}]
-     (.createCollection (get-db *mongo-config*)
-                        ^String (named collection)
-                        (coerce options [:clojure :mongo]))))
+  [collection & {:keys [capped size max] :as options}]
+  ;; Work around mongo bug JAVA-1970 by calling get-coll when options is
+  ;; nil
+  (if (some? options)
+    (.createCollection (get-db *mongo-config*)
+                       ^String (named collection)
+                       (coerce options [:clojure :mongo]))
+    (get-coll collection)))
 
 (def query-option-map
   {:tailable    Bytes/QUERYOPTION_TAILABLE

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -27,7 +27,8 @@
             [somnium.congomongo.config :only [*mongo-config*]]
             [somnium.congomongo.coerce :only [coerce coerce-fields coerce-index-fields]])
   (:import  [com.mongodb MongoClient MongoClientOptions MongoClientOptions$Builder MongoClientURI
-             DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes]
+                         DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes
+                         MapReduceCommand MapReduceCommand$OutputType]
             [com.mongodb.gridfs GridFS]
             [com.mongodb.util JSON]
             [org.bson.types ObjectId]))
@@ -40,6 +41,10 @@
   (named [s] (name s))
   Object
   (named [s] s))
+
+(defn named?
+  [s]
+  (instance? StringNamed s))
 
 (def ^{:private true
        :doc "To avoid yet another level of indirection via reflection, use
@@ -785,6 +790,14 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
         (:retval result)
         (throw (Exception. ^String (format "failure executing javascript: %s" (str result))))))))
 
+(defn- mapreduce-type
+  [k]
+  (get {:replace MapReduceCommand$OutputType/REPLACE
+        :merge   MapReduceCommand$OutputType/MERGE
+        :reduce  MapReduceCommand$OutputType/REDUCE}
+       k
+       MapReduceCommand$OutputType/INLINE))
+
 (defn map-reduce
   "Performs a map-reduce job on the server.
 
@@ -822,30 +835,44 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
   [collection mapfn reducefn out & {:keys [out-from query query-from sort sort-from limit finalize scope scope-from output as]
                                     :or {out-from :clojure query nil query-from :clojure sort nil sort-from :clojure
                                          limit nil finalize nil scope nil scope-from :clojure output :documents as :clojure}}]
-  (let [;; BasicDBObject requires key-value pairs in the correct order... apparently the first one
-        ;; must be :mapreduce
-        mr-query (->> [[:mapreduce collection]
-                       [:map mapfn]
-                       [:reduce reducefn]
-                       [:out (coerce out [out-from :mongo])]
-                       [:verbose true]
-                       (when query [:query (coerce query [query-from :mongo])])
-                       (when sort [:sort (coerce sort [sort-from :mongo])])
-                       (when limit [:limit limit])
-                       (when finalize [:finalize finalize])
-                       (when scope [:scope (coerce scope [scope-from :mongo])])]
-                      (remove nil?)
-                      flatten
-                      (apply array-map))
-        mr-query (coerce mr-query [:clojure :mongo])
-        ^com.mongodb.MapReduceOutput result (.mapReduce (get-coll collection) ^DBObject mr-query)]
-    (if (or (= output :documents)
-            (= (coerce out [out-from :clojure])
-               {:inline 1}))
-      (coerce (.results result) [:mongo as] :many true)
-      (-> (.getOutputCollection result)
+  (let [mr-query (coerce (or query {}) [query-from :mongo])
+        ;; The output collection and output-type are inherently bound to each
+        ;; other. If out is a string/keyword then the output type should be
+        ;; INLINE (and the out 'collection' converted to a string)
+        ;;
+        ;; If out is a map then it should have a single entry, the key is the
+        ;; output-type and the value is the output collection
+        [out-collection mr-type] (letfn [(convert-map [[k v]]
+                                          [(named v) (mapreduce-type k)])]
+                                  (cond
+                                    (= out {:inline 1}) [nil (mapreduce-type :inline)]
+                                    (map? out)          (-> out first convert-map)
+                                    (named? out)        [(named out) (mapreduce-type :replace)]))
+        ;; Verbose is true by default
+        ;; http://api.mongodb.org/java/3.0/com/mongodb/MapReduceCommand.html#setVerbose-java.lang.Boolean-
+        mr-command (MapReduceCommand. (get-coll collection)
+                                      mapfn
+                                      reducefn
+                                      (str out-collection)
+                                      mr-type
+                                      mr-query)]
+    (when sort
+      (.setSort mr-command (coerce sort [sort-from :mongo])))
+    (when limit
+      (.setLimit mr-command limit))
+    (when finalize
+      (.setFinalize mr-command finalize))
+    (when scope
+      (.setScope mr-command (coerce scope [scope-from :mongo])))
+
+    (let [^com.mongodb.MapReduceOutput result (.mapReduce (get-coll collection) mr-command)]
+      (if (or (= output :documents)
+              (= (coerce out [out-from :clojure])
+                 {:inline 1}))
+        (coerce (.results result) [:mongo as] :many true)
+        (-> (.getOutputCollection result)
             .getName
-            keyword))))
+            keyword)))))
 
 (defn group
   "Performs group operation on given collection

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -27,7 +27,7 @@
             [somnium.congomongo.config :only [*mongo-config*]]
             [somnium.congomongo.coerce :only [coerce coerce-fields coerce-index-fields]])
   (:import  [com.mongodb MongoClient MongoClientOptions MongoClientOptions$Builder MongoClientURI
-             DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes DBCursor]
+             DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes]
             [com.mongodb.gridfs GridFS]
             [com.mongodb.util JSON]
             [org.bson.types ObjectId]))
@@ -440,10 +440,11 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
                          ^DBObject n-where
                          ^DBObject n-only)]
                (coerce m [:mongo as]) nil)
-      :else  (when-let [cursor (DBCursor. ^DBCollection n-col
+      :else  (when-let [cursor (.find ^DBCollection n-col
                                       ^DBObject n-where
-                                      ^DBObject n-only
-                                      ^ReadPreference n-preferences)]
+                                      ^DBObject n-only)]
+               (when n-preferences
+                 (.setReadPreference cursor n-preferences))
                (when n-hint
                  (.hint cursor n-hint))
                (when n-options

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -483,7 +483,9 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
                  :clojure)
           f  (fn [[k v]]
                [k (if (db-ref? v)
-                    (coerce (.fetch ^DBRef v) [:mongo as])
+                    (let [v ^DBRef v
+                          coll (get-coll (.getCollectionName v))]
+                      (coerce (.findOne coll (.getId v)) [:mongo as]))
                     v)])]
       (postwalk (fn [x]
                   (if (map? x)

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -91,7 +91,7 @@
      *translations* {[:clojure :mongo  ] #'clojure->mongo
                      [:clojure :json   ] #'write-str
                      [:mongo   :clojure] #(mongo->clojure ^DBObject % ^Boolean/TYPE *keywordize*)
-                     [:mongo   :json   ] #(.toString ^DBObject %)
+                     [:mongo   :json   ] #(JSON/serialize %)
                      [:json    :clojure] #(read-str % :key-fn (if *keywordize*
                                                                 keyword
                                                                 identity))

--- a/src/somnium/congomongo/coerce.clj
+++ b/src/somnium/congomongo/coerce.clj
@@ -141,9 +141,14 @@
   (clojure->mongo ^IPersistentMap (apply array-map
                                          (flatten
                                           (for [f fields]
+                                            ;; https://jira.mongodb.org/browse/JAVA-1971
+                                            ;; means we need to be sure that numeric asc/desc specifiers are
+                                            ;; ints, not longs.
+                                            ;; NOTE: specifiers can be strings for geospatial indices, e.g.
+                                            ;; "2d", "2dsphere"
                                             (if (vector? f)
-                                              f
-                                              [f 1]))))))
+                                              (update f 1 (fn [x] (if (number? x) (int x) x)))
+                                              [f (int 1)]))))))
 
 (defn ^DBObject coerce-index-fields
   "Used for creating index specifications.

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -94,15 +94,15 @@
   (with-test-mongo
     ;; set some non-default option values
     (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port
-                             (mongo-options :auto-connect-retry true
+                             (mongo-options :connect-timeout 500
                                             :write-concern (:acknowledged write-concern-map)))
          ^MongoClient m (:mongo a)
-          opts (.getMongoOptions m)]
+          opts (.getMongoClientOptions m)]
       ;; check non-default options attached to Mongo object
-      (is (.isAutoConnectRetry opts))
+      (is (= 500 (.getConnectTimeout opts)))
       (is (= WriteConcern/ACKNOWLEDGED (.getWriteConcern opts)))
       ;; check a default option as well
-      (is (not (.slaveOk opts))))))
+      (is (= (ReadPreference/primary) (.getReadPreference opts))))))
 
 (deftest uri-for-connection
   (with-test-mongo

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -73,6 +73,22 @@
       (finally
         (teardown!)))))
 
+(defn- version
+  [db]
+  (-> *mongo-config*
+      :mongo
+      (.getDB db)
+      (.command "buildInfo")
+      (.getString "version")))
+
+(defn- mongo2?
+  [db]
+  (-> (version db) (.startsWith "2")))
+
+(defn- mongo3?
+  [db]
+  (-> (version db) (.startsWith "3")))
+
 (deftest options-on-connections
   (with-test-mongo
     ;; set some non-default option values
@@ -283,13 +299,8 @@
 
 (deftest fetch-with-hint-changes-index
   (with-test-mongo
-    (let [version (-> *mongo-config*
-                      :mongo
-                      (.getDB test-db)
-                      (.command "buildInfo")
-                      (.getString "version"))
-          mongo2? (-> version (.startsWith "2"))
-          mongo3? (-> version (.startsWith "3"))
+    (let [mongo2? (mongo2? test-db)
+          mongo3? (mongo3? test-db)
 
           query-index (fn [plan]
                         (cond

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -6,7 +6,8 @@
         somnium.congomongo.coerce
         clojure.pprint)
   (:use [clojure.data.json :only (read-str write-str)])
-  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder DuplicateKeyException
+  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder
+                        DuplicateKeyException MongoCommandException
                         Tag TagSet
             ReadPreference
             WriteConcern]))
@@ -892,3 +893,21 @@ function ()
           (is (thrown? NullPointerException (.createCollection db
                                                                "no-options-so-deferred-creation"
                                                                nil))))))))
+
+(deftest mongo-bug-JAVA-1971-canary
+  (testing "will fail when JAVA-1971 is fixed in mongo driver 3.0.x"
+    (with-test-mongo
+      (when (and (-> (mongo-client-version) (.startsWith "3"))
+                 (not (-> (version test-db) (.startsWith "2.4."))))
+        (insert! :test_col {:key1 1})
+
+        ;; Add key1 asc index
+        (.createIndex (get-coll :test_col)
+                      (coerce {:key1 1} [:clojure :mongo])
+                      (coerce {:unique false :sparse false :background false} [:clojure :mongo]))
+
+        ;; Add key1 desc index, fails until JAVA-1971 is fixed
+        (is (thrown-with-msg? MongoCommandException #"Trying to create an index with same name key1_ with different key spec \{ key1: -1 \}"
+          (.createIndex (get-coll :test_col)
+                        (coerce {:key1 -1} [:clojure :mongo])
+                        (coerce {:unique false :sparse false :background false} [:clojure :mongo])))) ))))

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -50,11 +50,13 @@
   (doseq [^String coll (collections)]
     (when-not (.startsWith coll "system")
       (drop-coll! coll))))
+
 (defn setup! []
   (mongo! :db test-db :host test-db-host :port test-db-port)
   (when (and test-db-user test-db-pass)
     (authenticate test-db-user test-db-pass)
     (drop-test-collections!)))
+
 (defn teardown! []
   (if (and test-db-user test-db-pass)
     (try ; some tests don't authenticate so ignore failures here:
@@ -65,8 +67,10 @@
 (defmacro with-test-mongo [& body]
   `(do
      (setup!)
-     ~@body
-     (teardown!)))
+     (try
+      ~@body
+      (finally
+        (teardown!)))))
 
 (deftest options-on-connections
   (with-test-mongo


### PR DESCRIPTION
Probably best reviewed on a commit-by-commit basis

The congomongo interface hasn't been modified but I've had to change the internals a bit.

I'm not that happy with the `map-reduce` changes but they work.

For the most part I've been able to avoid modifying tests so I'm pretty confident that this works, but I need to hook it up to https://github.com/circleci/mongofinil and https://github.com/circleci/circle to be sure