### PR TITLE
Revamp make-connection to accomodate the new authentication mechanism

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject circleci/congomongo
-  "0.4.6"
+  "0.5.0"
   :description "Clojure-friendly API for MongoDB"
   :url "https://github.com/aboekhoff/congomongo"
   :mailing-list {:name "CongoMongo mailing list"

--- a/readme.markdown
+++ b/readme.markdown
@@ -9,6 +9,16 @@ For Clojure 1.2.1 and earlier, use CongoMongo 0.2.3 or earlier. CongoMongo 0.2.3
 
 News
 --------------
+Version 0.5.0 - Sep 25th, 2015
+
+Updated to support mongo-java-driver 3.0+ which enables use of TLS connections.
+Authentication has changed significantly in the 3.0 driver which necessitated some breaking API changes around connecting and authenticating.
+
+BREAKING CHANGES IN THIS RELEASE!
+* Usernames and passwords for authenticated connections must be supplied to `make-connection` rather than authenticating after the connection has been created. The `make-connection` API has been changed to accomodate this. Optional parameters (instances, Mongo options, username and password) are now passed via keyword args.
+* The `authenticate` function has been removed.
+* The deprecated `mongo!` function has been removed. Use `(set-connection (make-connection ...))`
+
 Version 0.4.6 - Jul 29th, 2015
 
 * Add support for hints on fetches

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -111,8 +111,8 @@
 (defn- make-connection-args
   "Makes a connection with passed database name, host, port and MongoClientOptions"
   [db {:keys [instances options username password]}]
-  (when (or username password)
-    (assert (and username password) "Username and password must be supplied for authenticated connections"))
+  (when (not= (some? username) (some? password))
+    (throw (IllegalArgumentException. "Username and password must both be supplied for authenticated connections")))
 
   (let [addresses (->> (if (keyword? (first instances))
                          (list (apply array-map instances)) ; Handle legacy connect args

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -27,7 +27,9 @@
             [somnium.congomongo.config :only [*mongo-config*]]
             [somnium.congomongo.coerce :only [coerce coerce-fields coerce-index-fields]])
   (:import  [com.mongodb MongoClient MongoClientOptions MongoClientOptions$Builder MongoClientURI
-                         DB DBCollection DBObject DBRef ServerAddress ReadPreference WriteConcern Bytes
+                         MongoCredential
+                         DB DBCollection DBObject DBRef
+                         ServerAddress ReadPreference WriteConcern Bytes
                          MapReduceCommand MapReduceCommand$OutputType]
             [com.mongodb.gridfs GridFS]
             [com.mongodb.util JSON]
@@ -95,20 +97,39 @@
   [^String host ^Integer port]
   (ServerAddress. host port))
 
+(defn- make-mongo-client
+  ([addresses creds options]
+    (if (> (count addresses) 1)
+      (MongoClient. ^java.util.List addresses creds options)
+      (MongoClient. ^ServerAddress (first addresses) creds options)))
+
+  ([addresses options]
+    (if (> (count addresses) 1)
+      (MongoClient. ^java.util.List addresses options)
+      (MongoClient. ^ServerAddress (first addresses) options))))
+
 (defn- make-connection-args
   "Makes a connection with passed database name, host, port and MongoClientOptions"
-  [db args]
-    (let [instances (take-while #(not (instance? MongoClientOptions %)) args)
-          addresses (->> (if (keyword? (first instances))
-                           (list (apply array-map instances)) ; Handle legacy connect args
-                           instances)
-                      (map (fn [{:keys [host port] :or {host "127.0.0.1" port 27017}}]
-                             (make-server-address host port))))
-          ^MongoClientOptions options (or (first (filter #(instance? MongoClientOptions %) args)) (mongo-options))
-          mongo (if (> (count addresses) 1)
-                  (MongoClient. ^java.util.List addresses options)
-                  (MongoClient. ^ServerAddress (first addresses) options))
-          n-db (if db (.getDB mongo db) nil)]
+  [db {:keys [instances options username password]}]
+  (when (or username password)
+    (assert (and username password) "Username and password must be supplied for authenticated connections"))
+
+  (let [addresses (->> (if (keyword? (first instances))
+                         (list (apply array-map instances)) ; Handle legacy connect args
+                         instances)
+                    (map (fn [{:keys [host port] :or {host "127.0.0.1" port 27017}}]
+                           (make-server-address host port))))
+        ^MongoClientOptions options (or options (mongo-options))
+
+
+        mongo (cond
+                (and username password) (make-mongo-client
+                                          addresses
+                                          [(MongoCredential/createCredential username db (.toCharArray password))]
+                                          options)
+                :else (make-mongo-client addresses options))
+
+        n-db (if db (.getDB mongo db) nil)]
       {:mongo mongo :db n-db}))
 
 (defn- make-connection-uri
@@ -117,32 +138,39 @@
   (let [^MongoClientURI mongouri (MongoClientURI. db)
         ^MongoClient client (MongoClient. mongouri)
         ^String db (.getDatabase mongouri)
-        conn {:mongo client :db (.getDB client db)}
-        ^DB db (conn :db)
-        ^String username (.getUsername mongouri)
-        ^chars password (.getPassword mongouri)]
-    (when (and username password)
-      (.authenticate db username password))
+        conn {:mongo client :db (.getDB client db)}]
     conn))
 
 (defn make-connection
   "Connects to one or more mongo instances, returning a connection
-that can be used with set-connection! and with-mongo. Each instance is
-a map containing values for :host and/or :port.
+  that can be used with set-connection! and with-mongo.
+
+  Each instance is a map containing values for :host and/or :port.
+
   May be called with database name and optionally:
-    host (default: 127.0.0.1)
-    port (default: 27017)
-    A MongoClientOptions object
+    :instances - a list of server instances to connect to
+    :options - a MongoClientOptions object
+    :username - the username to authenticate with
+    :password - the password to authenticate with
+
+  If instances are not specified a connection is made to 127.0.0.1:27017
+
+  Username and password must be supplied for authenticated connections.
+
   A MongoClientURI string is also supported and must be prefixed with mongodb://
-  If username and password are specified, authenticate will be immediately
-  called on the connection."
+  If username and password are specified the connection will be authenticated."
+  {:arglists '([db :instances [{:host host, :port port}]
+                   :options mongo-options
+                   :username username
+                   :password password]
+               [mongo-client-uri])}
   ([db]
     (make-connection db {}))
   ([db & args]
     (let [^String dbname (named db)]
       (if (.startsWith dbname "mongodb://")
         (make-connection-uri dbname)
-        (make-connection-args dbname args)))))
+        (make-connection-args dbname (apply hash-map args))))))
 
 (defn connection?
   "Returns truth if the argument is a map specifying an active connection."
@@ -196,34 +224,6 @@ When with-mongo and set-connection! interact, last one wins"
                   (constantly connection)
                   (when (thread-bound? #'*mongo-config*)
                     (set! *mongo-config* connection))))
-
-(defn mongo!
-  "Creates a Mongo object and sets the default database.
-
-Does not support replica sets, and will be deprecated in future
-releases.  Please use 'make-connection' in combination with
-'with-mongo' or 'set-connection!' instead.
-
-   Keyword arguments include:
-   :host -> defaults to localhost
-   :port -> defaults to 27017
-   :db   -> defaults to nil (you'll have to set it anyway, might as well do it now.)"
-  {:arglists '([:db ? :host "localhost" :port 27017])}
-  [& {:keys [db host port]
-      :or {db nil host "localhost" port 27017}}]
-  (set-connection! (make-connection db :host host :port port))
-  true)
-
-(defn authenticate
-  "Authenticate against either the current or a specified database connection."
-  ([conn username password]
-     (let [db (get-db conn)]
-       (when-not (.isAuthenticated db)
-         (.authenticate db
-                        ^String username
-                        (.toCharArray ^String password)))))
-  ([username password]
-     (authenticate *mongo-config* username password)))
 
 (definline ^DBCollection get-coll
   "Returns a DBCollection object"

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -187,6 +187,19 @@
 
           (close-connection conn))))))
 
+(deftest make-connection-variations
+  (testing "No optional arguments"
+    (is (make-connection test-db)))
+
+  (testing "Username/password combinations"
+    (is (thrown-with-msg? IllegalArgumentException #"Username and password must both be supplied"
+          (make-connection test-db :username "foo" :password nil)))
+
+    (is (thrown-with-msg? IllegalArgumentException #"Username and password must both be supplied"
+          (make-connection test-db :username nil :password "bar")))
+
+    (is (make-connection test-db :username nil :password nil))))
+
 (deftest options-on-connections
   (with-test-mongo
     ;; set some non-default option values

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -6,8 +6,10 @@
         somnium.congomongo.coerce
         clojure.pprint)
   (:use [clojure.data.json :only (read-str write-str)])
-  (:import [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder
-                        DuplicateKeyException MongoCommandException
+  (:import [java.nio.charset Charset]
+           [java.security MessageDigest]
+           [com.mongodb MongoClient DB DBObject BasicDBObject BasicDBObjectBuilder
+                        MongoException DuplicateKeyException MongoCommandException
                         Tag TagSet
             ReadPreference
             WriteConcern]))
@@ -54,10 +56,10 @@
       (drop-coll! coll))))
 
 (defn setup! []
-  (mongo! :db test-db :host test-db-host :port test-db-port)
-  (when (and test-db-user test-db-pass)
-    (authenticate test-db-user test-db-pass)
-    (drop-test-collections!)))
+  (set-connection! (make-connection test-db :instances [{:host test-db-host :port test-db-port}]
+                                            :username test-db-user
+                                            :password test-db-pass))
+  (drop-test-collections!))
 
 (defn teardown! []
   (if (and test-db-user test-db-pass)
@@ -90,12 +92,107 @@
   [db]
   (-> (version db) (.startsWith "3")))
 
+(defn- mongo-hash
+  "Uses the same hashing algorithm as
+  https://github.com/mongodb/mongo/blob/09917767b116f4ff1c0eadda1e8bc5db30828500/src/mongo/shell/db.js#L149"
+  [username passphrase]
+  (let [hex-strings (vec (for [a ["0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f"]
+                               b ["0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f"]]
+                           (str a b)))
+        ->bytes (fn [s] (.getBytes s (Charset/forName "UTF-8")))
+        digest-bytes (.digest
+                        (doto (MessageDigest/getInstance "MD5")
+                              (.reset)
+                              (.update (->bytes username))
+                              (.update (->bytes ":mongo:"))
+                              (.update (->bytes passphrase))))]
+    (apply str (map #(get hex-strings (bit-and 0xff %)) digest-bytes))))
+
+(defmacro with-test-user
+  [username password & body]
+  `(let [username# ~username
+         password# ~password]
+    (try
+      (cond
+        (= "2.2" (subs (version test-db) 0 3))
+        ;; 2.2 uses a different user creation algorithm to 2.4
+        (is false "Not implemented for 2.2 databases")
+
+        (= "2.4" (subs (version test-db) 0 3))
+        ;; 2.4 mongodb doesn't have a command to create users. Manually hash
+        ;; the password and insert directly
+        (insert! :system.users {:user username#
+                                :pwd (mongo-hash username# password#)
+                                :roles ["readWrite"]})
+
+        :else
+        (let [create-user-cmd# (.. (BasicDBObjectBuilder/start)
+                                   (add "createUser" username#)
+                                   (add "pwd" password#)
+                                   (add "roles" [(BasicDBObject. {"role" "readWrite", "db" test-db})])
+                                   (get))]
+          (.command ^DB (get-db *mongo-config*)
+                    ^DBObject create-user-cmd#)))
+      ~@body
+      (finally
+        (.command ^DB (get-db *mongo-config*)
+                  ^DBObject (coerce {:dropUser username#} [:clojure :mongo]))))))
+
+(deftest authentication-works
+  (with-test-mongo
+    (with-test-user "test_user" "test_password"
+      (testing "valid credentials work"
+        (let [conn (make-connection test-db :instances [{:host test-db-host :port test-db-port}]
+                                            :username "test_user"
+                                            :password "test_password")]
+          ;; Just validate that we can interact with the DB, the 3.0 Mongo driver
+          ;; has removed any way to check if a connection is authenticated.
+          (with-mongo conn
+            (insert! :thingies {:foo 1})
+            (is (= 1 (:foo (fetch-one :thingies :where {:foo 1}))))
+
+          (close-connection conn))))
+
+      (testing "invalid credentials throw"
+        (let [conn (make-connection test-db :instances [{:host test-db-host :port test-db-port}]
+                                            :options (mongo-options :server-selection-timeout 1000)
+                                            :username "not_a_valid_user"
+                                            :password "not_a_valid_password")]
+          (is (thrown? MongoException
+                       (with-mongo conn
+                         (insert! :thingies {:foo 1}))))
+
+          (close-connection conn)))
+
+      (testing "credentials with Mongo URIs"
+        (let [conn (make-connection (format "mongodb://test_user:test_password@127.0.0.1:27017/%s" test-db))]
+          ;; Just validate that we can interact with the DB, the 3.0 Mongo driver
+          ;; has removed any way to check if a connection is authenticated.
+          (with-mongo conn
+            (insert! :thingies {:foo 1})
+            (is (= 1 (:foo (fetch-one :thingies :where {:foo 1}))))
+
+          (close-connection conn))))
+
+      (testing "bad credentials in a MongoURI"
+        ;; This adds a 30 second wait to the test suite when using the 3.0 driver.
+        ;; Since all connections are authenticated the server selection times
+        ;; out due to invalid credentials.
+        ;; Unlike MongoClient, http://api.mongodb.org/java/current/com/mongodb/MongoClientURI.html
+        ;; does not allow the server selection timeout to be set
+        (let [conn (make-connection (format "mongodb://invalid_user:test_password@127.0.0.1:27017/%s" test-db))]
+          (is (thrown? MongoException
+                       (with-mongo conn
+                         (insert! :thingies {:foo 1}))))
+
+          (close-connection conn))))))
+
 (deftest options-on-connections
   (with-test-mongo
     ;; set some non-default option values
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port
-                             (mongo-options :connect-timeout 500
-                                            :write-concern (:acknowledged write-concern-map)))
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}]
+                                                   :options (mongo-options :connect-timeout 500
+                                                                           :write-concern (:acknowledged write-concern-map)))
          ^MongoClient m (:mongo a)
           opts (.getMongoClientOptions m)]
       ;; check non-default options attached to Mongo object
@@ -120,7 +217,7 @@
 
 (deftest with-mongo-database
   (with-test-mongo
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)]
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}])]
       (with-mongo a
         (with-db "congomongotest-db-b"
           (testing "with-mongo uses new database"
@@ -130,20 +227,20 @@
 
 (deftest with-mongo-interactions
   (with-test-mongo
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)
-          b (make-connection :congomongotest-db-b :host test-db-host :port test-db-port)]
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}])
+          b (make-connection :congomongotest-db-b :instances [{:host test-db-host :port test-db-port}])]
       (with-mongo a
         (testing "with-mongo sets the mongo-config"
           (is (= "congomongotest-db-a" (.getName ^DB (*mongo-config* :db)))))
-        (testing "mongo! inside with-mongo stomps on current config"
-          (mongo! :db "congomongotest-db-b" :host test-db-host :port test-db-port)
-          (is (= "congomongotest-db-b" (.getName ^DB (*mongo-config* :db))))))
-      (testing "and previous mongo! inside with-mongo is visible afterwards"
-        (is (= "congomongotest-db-b" (.getName ^DB (*mongo-config* :db))))))))
+        (testing "set-connection! inside with-mongo stomps on current config"
+          (set-connection! (make-connection "congomongotest-db-c" :instances [{:host test-db-host :port test-db-port}]))
+          (is (= "congomongotest-db-c" (.getName ^DB (*mongo-config* :db))))))
+      (testing "and previous set-connection! inside with-mongo is visible afterwards"
+        (is (= "congomongotest-db-c" (.getName ^DB (*mongo-config* :db))))))))
 
 (deftest closing-with-mongo
   (with-test-mongo
-    (let [a (make-connection "congomongotest-db-a" :host test-db-host :port test-db-port)]
+    (let [a (make-connection "congomongotest-db-a" :instances [{:host test-db-host :port test-db-port}])]
       (with-mongo a
         (testing "close-connection inside with-mongo sets mongo-config to nil"
           (close-connection a)


### PR DESCRIPTION
The new authentication mechanism in Mongo driver 3.0 requires
credentials to be passed to the MongoClient constructor.
This has the knock-on effect of requiring username/password to be passed
to make-connection.

Rather than trying to adapt the previous approach which pulled args out
of the fn args by type I've made the different optional connection args
explicit keyword-style arguments.

This is the first API-incompatible change I've had to make.