### PR TITLE
Respect read-preferences from fetch-one

### DIFF
--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -412,8 +412,8 @@ When with-mongo and set-connection! interact, last one wins"
   (when (and one? sort)
     (throw (IllegalArgumentException. "Fetch :one? (or fetch-one) can't be used with :sort.
 You should use fetch with :limit 1 instead."))); one? and sort should NEVER be called together
-  (when (and one? (or read-preferences (not= [] options) (not= 0 limit) hint explain?))
-    (throw (IllegalArgumentException. "At the moment, fetch-one doesn't support read-preferences, options, limit or hint"))) ;; these are allowed but not implemented here
+  (when (and one? (or (not= [] options) (not= 0 limit) hint explain?))
+    (throw (IllegalArgumentException. "At the moment, fetch-one doesn't support options, limit, or hint"))) ;; these are allowed but not implemented here
   (when-not (or (nil? hint)
                 (string? hint)
                 (and (instance? clojure.lang.Sequential hint)
@@ -439,11 +439,14 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
                         :else (somnium.congomongo/read-preference read-preferences))]
     (cond
       count? (.getCount n-col n-where n-only)
-      one?   (if-let [m (.findOne
-                         ^DBCollection n-col
-                         ^DBObject n-where
-                         ^DBObject n-only)]
-               (coerce m [:mongo as]) nil)
+
+      ;; The find command isn't documented so there's no nice way to build a
+      ;; find command that adds read-preferences when necessary
+      one?   (if-let [m (if (some? n-preferences)
+                          (.findOne ^DBCollection n-col ^DBObject n-where ^DBObject n-only ^ReadPreference n-preferences)
+                          (.findOne ^DBCollection n-col ^DBObject n-where ^DBObject n-only))]
+              (coerce m [:mongo as]) nil)
+
       :else  (when-let [cursor (.find ^DBCollection n-col
                                       ^DBObject n-where
                                       ^DBObject n-only)]

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -350,10 +350,10 @@
     (is (thrown? IllegalArgumentException
                  (fetch-one :stuff :sort {:a 1})))))
 
-(deftest fetch-one-with-read-preferences-fails
+(deftest fetch-one-with-read-preferences-does-not-explode
   (with-test-mongo
-    (is (thrown? IllegalArgumentException
-                 (fetch-one :test_col :read-preferences :secondary)))))
+    (insert! :test_col {:foo "bar"})
+    (is (fetch-one :test_col :read-preferences :secondary))))
 
 (deftest fetch-one-with-hint-fails
   (with-test-mongo


### PR DESCRIPTION
This isn't the prettiest because there's no exposed escape-hatch for executing `find` commands but it works.