### PR TITLE
Add ability to set timeout on fetch and fetch-and-modify operations

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -278,6 +278,9 @@ Developer information
 
 Change Log
 ----------
+Version 1.0.2 - Apr 5, 2019
+Added ability to specify timeout for fetch and fetch-and-modify operations
+
 Version 1.0.1 - Sep 11, 2018
 Fixed bug where too few documents were returned if fetching with a limit that was larger than the
 default batch size.

--- a/test/somnium/test/congomongo.clj
+++ b/test/somnium/test/congomongo.clj
@@ -12,7 +12,7 @@
                         MongoClient MongoException DuplicateKeyException MongoCommandException
                         Tag TagSet
                         ReadPreference
-                        WriteConcern]
+                        WriteConcern MongoExecutionTimeoutException]
            [org.bson.types ObjectId]))
 
 (deftest coercions
@@ -582,12 +582,15 @@
           "changed DB exists")
       (drop-database! test-db2))))
 
-(defn make-points! []
-  (println "slow insert of 10000 points:")
-  (time
-   (doseq [x (range 100)
-           y (range 100)]
-     (insert! :points {:x x :y y}))))
+(defn make-points!
+  ([]
+   (make-points! 100))
+  ([num-points]
+   (println "slow insert of " (* num-points num-points) " points:")
+   (time
+    (doseq [x (range num-points)
+            y (range num-points)]
+      (insert! :points {:x x :y y})))))
 
 (deftest slow-insert-and-fetch
   (with-test-mongo


### PR DESCRIPTION
This will set maxTime in milliseconds: https://mongodb.github.io/mongo-java-driver/3.4/javadoc/com/mongodb/DBCursor.html#maxTime-long-java.util.concurrent.TimeUnit-