### PR TITLE
CIRCLE-19405 added support for default query options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject congomongo
-  "1.1.1-SNAPSHOT"
+(defproject circleci/congomongo
+  "1.2.0-SNAPSHOT"
   :description "Clojure-friendly API for MongoDB"
   :url "https://github.com/congomongo/congomongo"
   :mailing-list {:name "CongoMongo mailing list"
@@ -10,7 +10,7 @@
             :distribution :repo}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/data.json "0.2.6"]
-                 [org.mongodb/mongo-java-driver "3.8.1"]
+                 [org.mongodb/mongo-java-driver "3.10.2"]
                  [org.clojure/clojure "1.9.0" :scope "provided"]]
   :deploy-repositories {"releases" {:url "https://repo.clojars.org" :creds :gpg}}
   ;; if a :dev profile is added, remember to update :aliases below to

--- a/readme.markdown
+++ b/readme.markdown
@@ -275,6 +275,13 @@ Developer information
 
 Change Log
 ----------
+Version 1.2.0 - November 13, 2019
+* Added support for authentication source using one of the following authentication mechanisms:
+  AuthenticationMechanism.PLAIN, 
+  AuthenticationMechanism.SCRAM_SHA_1,
+  AuthenticationMechanism.SCRAM_SHA_256
+* Updated mongo-java-driver to 3.10.2
+
 Version 1.1.0 - Apr 8, 2019
 Added ability to specify timeout for fetch and fetch-and-modify operations.
 

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -110,23 +110,38 @@
   "Makes a connection with passed database name, [{:host host, :port port}]
   server addresses and MongoClientOptions.
 
-  username and password may be supplied for authenticated connections."
-  [db {:keys [instances options username password]}]
+  username, password, and optionally auth-source, may be supplied for authenticated connections."
+  [db {:keys [instances options username password] {auth-mechanism :mechanism auth-source :source} :auth-source}]
   (when (not= (nil? username) (nil? password))
     (throw (IllegalArgumentException. "Username and password must both be supplied for authenticated connections")))
 
   (let [addresses (map (fn [{:keys [host port] :or {host "127.0.0.1" port 27017}}]
-                        (make-server-address host port))
+                         (make-server-address host port))
                        (or instances [{:host "127.0.0.1" :port 27017}]))
 
         ^MongoClientOptions options (or options (mongo-options))
+        ^MongoCredential credential (cond
+                                      (and username password (= :plain auth-mechanism))
+                                      (MongoCredential/createPlainCredential username auth-source
+                                                                             (.toCharArray password))
 
-        mongo (cond
-                (and username password) (make-mongo-client
-                                          addresses
-                                          [(MongoCredential/createCredential username db (.toCharArray password))]
-                                          options)
-                :else (make-mongo-client addresses options))
+                                      (and username password (= :scram-1 auth-mechanism))
+                                      (MongoCredential/createScramSha1Credential username auth-source
+                                                                                 (.toCharArray password))
+
+                                      (and username password (= :scram-256 auth-mechanism))
+                                      (MongoCredential/createScramSha256Credential username auth-source
+                                                                                   (.toCharArray password))
+
+                                      auth-mechanism
+                                      (throw (UnsupportedOperationException. (str auth-mechanism " is not supported.")))
+
+                                      (and username password)
+                                      (MongoCredential/createCredential username db (.toCharArray password)))
+
+        mongo (if credential
+                (make-mongo-client addresses [credential] options)
+                (make-mongo-client addresses options))
 
         n-db (if db (.getDB mongo db) nil)]
       {:mongo mongo :db n-db}))
@@ -151,6 +166,12 @@
     :options - a MongoClientOptions object
     :username - the username to authenticate with
     :password - the password to authenticate with
+    :auth-source - the authentication source for authenticated connections in form:
+      {:mechanism mechanism :source source}
+      Supported authentication mechanisms:
+        :plain
+        :scram-1
+        :scram-256
 
   If instances are not specified a connection is made to 127.0.0.1:27017
 
@@ -162,7 +183,8 @@
   {:arglists '([db :instances [{:host host, :port port}]
                    :options mongo-options
                    :username username
-                   :password password]
+                   :password password
+                   :auth-source {:mechanism mechanism :source source}]
                [mongo-client-uri])}
   [db & {:as args}]
   (let [^String dbname (named db)]

--- a/src/somnium/congomongo.clj
+++ b/src/somnium/congomongo.clj
@@ -24,7 +24,7 @@
   somnium.congomongo
   (:require [clojure.string]
             [clojure.walk :refer (postwalk)]
-            [somnium.congomongo.config :refer [*mongo-config*]]
+            [somnium.congomongo.config :refer [*mongo-config* *default-query-options*]]
             [somnium.congomongo.coerce :refer [coerce coerce-fields coerce-index-fields]])
   (:import [com.mongodb MongoClient MongoClientOptions MongoClientOptions$Builder
                         MongoClientURI MongoCredential
@@ -236,6 +236,12 @@
      (binding [*mongo-config* (assoc *mongo-config* :db db#)]
        ~@body)))
 
+(defmacro with-default-query-options
+  [options & body]
+  `(do
+     (binding [*default-query-options* ~options]
+       ~@body)))
+
 (defn set-connection!
   "Makes the connection active. Takes a connection created by make-connection.
 
@@ -427,88 +433,91 @@ When with-mongo and set-connection! interact, last one wins"
    :max-time-ms      -> set the maximum execution time for operations"
   {:arglists
    '([collection :where :only :limit :skip :as :from :one? :count? :sort :hint :explain? :options :max-time-ms :read-preferences])}
-  [coll & {:keys [where only as from one? count? limit skip sort hint options explain? max-time-ms read-preferences]
-           :or {where {} only [] as :clojure from :clojure
-                one? false count? false limit 0 skip 0 sort nil hint nil options [] explain? false}}]
-  (when (and one? sort)
-    (throw (IllegalArgumentException. "Fetch :one? (or fetch-one) can't be used with :sort.
+  [coll & {:as params}]
+  (let [{:keys [where only as from one? count? limit skip sort hint options explain? max-time-ms read-preferences]}
+        (merge {:where {} :only [] :as :clojure :from :clojure
+                 :one? false :count? false :limit 0 :skip 0 :sort nil :hint nil :options [] :explain? false}
+                *default-query-options*
+                params)]
+    (when (and one? sort)
+      (throw (IllegalArgumentException. "Fetch :one? (or fetch-one) can't be used with :sort.
 You should use fetch with :limit 1 instead."))); one? and sort should NEVER be called together
-  (when (and one? (or (not= [] options) (not= 0 limit) hint explain?))
-    (throw (IllegalArgumentException. "At the moment, fetch-one doesn't support options, limit, or hint"))) ;; these are allowed but not implemented here
-  (when-not (or (nil? hint)
-                (string? hint)
-                (and (instance? clojure.lang.Sequential hint)
-                     (every? #(or (keyword? %)
-                                  (and (instance? clojure.lang.Sequential %)
-                                       (= 2 (count %))
-                                       (-> % first keyword?)
-                                       (-> % second #{1 -1})))
-                             hint)))
-    (throw (IllegalArgumentException. ":hint requires a string name of the index, or a seq of keywords that is the index definition")))
-  (let [n-where (coerce where [from :mongo])
-        n-only  (coerce-fields only)
-        n-col   (get-coll coll)
-        ; congomongo originally used do convert passed `limit` into negative number because mongo
-        ; protocol says:
-        ;  > If the number is negative, then the database will return that number and close the
-        ;  > cursor. No further results for that query can be fetched.
-        ; (see https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op-query)
-        ;
-        ;  But after bumping mongo-driver from 3.0.2 to 3.2.2 we discovered that
-        ;  if a number of available matching records in mongo is bigger than `batchSize`
-        ;  (101 by default) and limit is a negative number then mongo will return only `batchSize`
-        ;  of results and close the cursor. Which is in agreement with mongo shell docs:
-        ;   > A negative limit is similar to a positive limit but closes the cursor after
-        ;   > returning a single batch of results. As such, with a negative limit, if the
-        ;   > limited result set does not fit into a single batch, the number of documents
-        ;   > received will be less than the specified limit. By passing a negative limit,
-        ;   > the client indicates to the server that it will not ask for a subsequent batch
-        ;   > via getMore.
-        ;  (see https://docs.mongodb.com/manual/reference/method/cursor.limit/#negative-values)
-        ;
-        ; Maybe protocol description implies that number can't be bigger than a `batchSize`
-        ; or maybe protocol has been changed and docs aren't updated. Anyway current behaviour
-        ; (with negative limit) doesn't match expectations therefore changed to keep limit as is.
-        n-limit (or limit 0)
-        n-sort (when sort (coerce sort [from :mongo]))
-        n-options (calculate-query-options options)
-        n-hint (cond (string? hint) hint
-                     (nil? hint) nil
-                     :else (coerce-index-fields hint))
-        n-preferences (cond
-                        (nil? read-preferences) nil
-                        (instance? ReadPreference read-preferences) read-preferences
-                        :else (somnium.congomongo/read-preference read-preferences))]
-    (cond
-      count? (.getCount n-col n-where n-only)
+    (when (and one? (or (not= [] options) (not= 0 limit) hint explain?))
+      (throw (IllegalArgumentException. "At the moment, fetch-one doesn't support options, limit, or hint"))) ;; these are allowed but not implemented here
+    (when-not (or (nil? hint)
+                  (string? hint)
+                  (and (instance? clojure.lang.Sequential hint)
+                       (every? #(or (keyword? %)
+                                    (and (instance? clojure.lang.Sequential %)
+                                         (= 2 (count %))
+                                         (-> % first keyword?)
+                                         (-> % second #{1 -1})))
+                               hint)))
+      (throw (IllegalArgumentException. ":hint requires a string name of the index, or a seq of keywords that is the index definition")))
+    (let [n-where (coerce where [from :mongo])
+          n-only  (coerce-fields only)
+          n-col   (get-coll coll)
+                                        ; congomongo originally used do convert passed `limit` into negative number because mongo
+                                        ; protocol says:
+                                        ;  > If the number is negative, then the database will return that number and close the
+                                        ;  > cursor. No further results for that query can be fetched.
+                                        ; (see https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#op-query)
+                                        ;
+                                        ;  But after bumping mongo-driver from 3.0.2 to 3.2.2 we discovered that
+                                        ;  if a number of available matching records in mongo is bigger than `batchSize`
+                                        ;  (101 by default) and limit is a negative number then mongo will return only `batchSize`
+                                        ;  of results and close the cursor. Which is in agreement with mongo shell docs:
+                                        ;   > A negative limit is similar to a positive limit but closes the cursor after
+                                        ;   > returning a single batch of results. As such, with a negative limit, if the
+                                        ;   > limited result set does not fit into a single batch, the number of documents
+                                        ;   > received will be less than the specified limit. By passing a negative limit,
+                                        ;   > the client indicates to the server that it will not ask for a subsequent batch
+                                        ;   > via getMore.
+                                        ;  (see https://docs.mongodb.com/manual/reference/method/cursor.limit/#negative-values)
+                                        ;
+                                        ; Maybe protocol description implies that number can't be bigger than a `batchSize`
+                                        ; or maybe protocol has been changed and docs aren't updated. Anyway current behaviour
+                                        ; (with negative limit) doesn't match expectations therefore changed to keep limit as is.
+          n-limit (or limit 0)
+          n-sort (when sort (coerce sort [from :mongo]))
+          n-options (calculate-query-options options)
+          n-hint (cond (string? hint) hint
+                       (nil? hint) nil
+                       :else (coerce-index-fields hint))
+          n-preferences (cond
+                          (nil? read-preferences) nil
+                          (instance? ReadPreference read-preferences) read-preferences
+                          :else (somnium.congomongo/read-preference read-preferences))]
+      (cond
+        count? (.getCount n-col n-where n-only)
 
-      ;; The find command isn't documented so there's no nice way to build a
-      ;; find command that adds read-preferences when necessary
-      one?   (if-let [m (if (not (nil? n-preferences))
-                          (.findOne ^DBCollection n-col ^DBObject n-where ^DBObject n-only ^ReadPreference n-preferences)
-                          (.findOne ^DBCollection n-col ^DBObject n-where ^DBObject n-only))]
-              (coerce m [:mongo as]) nil)
+        ;; The find command isn't documented so there's no nice way to build a
+        ;; find command that adds read-preferences when necessary
+        one?   (if-let [m (if (not (nil? n-preferences))
+                            (.findOne ^DBCollection n-col ^DBObject n-where ^DBObject n-only ^ReadPreference n-preferences)
+                            (.findOne ^DBCollection n-col ^DBObject n-where ^DBObject n-only))]
+                 (coerce m [:mongo as]) nil)
 
-      :else  (when-let [cursor (.find ^DBCollection n-col
-                                      ^DBObject n-where
-                                      ^DBObject n-only)]
-               (when n-preferences
-                 (.setReadPreference cursor n-preferences))
-               (when n-hint
-                 (.hint cursor n-hint))
-               (when n-options
-                 (.setOptions cursor n-options))
-               (when n-sort
-                 (.sort cursor n-sort))
-               (when skip
-                 (.skip cursor skip))
-               (when n-limit
-                 (.limit cursor n-limit))
-               (when max-time-ms
-                 (.maxTime cursor max-time-ms TimeUnit/MILLISECONDS))
-               (if explain?
-                 (coerce (.explain cursor) [:mongo as] :many false)
-                 (coerce cursor [:mongo as] :many true))))))
+        :else  (when-let [cursor (.find ^DBCollection n-col
+                                        ^DBObject n-where
+                                        ^DBObject n-only)]
+                 (when n-preferences
+                   (.setReadPreference cursor n-preferences))
+                 (when n-hint
+                   (.hint cursor n-hint))
+                 (when n-options
+                   (.setOptions cursor n-options))
+                 (when n-sort
+                   (.sort cursor n-sort))
+                 (when skip
+                   (.skip cursor skip))
+                 (when n-limit
+                   (.limit cursor n-limit))
+                 (when max-time-ms
+                   (.maxTime cursor max-time-ms TimeUnit/MILLISECONDS))
+                 (if explain?
+                   (coerce (.explain cursor) [:mongo as] :many false)
+                   (coerce cursor [:mongo as] :many true)))))))
 
 (defn fetch-one [col & options]
   (apply fetch col (concat options '[:one? true])))
@@ -615,19 +624,21 @@ You should use fetch with :limit 1 instead."))); one? and sort should NEVER be c
        :max-time-ms -> set the maximum execution time for operations"
   {:arglists '([collection where update {:only nil :sort nil :remove? false
                                          :return-new? false :upsert? false :max-time-ms 0 :from :clojure :as :clojure}])}
-  [coll where update & {:keys [only sort remove? return-new? upsert? from as max-time-ms]
-                        :or {only nil sort nil remove? false
-                             return-new? false upsert? false
-                             max-time-ms 0
-                             from :clojure as :clojure}}]
-  (coerce (.findAndModify ^DBCollection (get-coll coll)
-                          ^DBObject (coerce where [from :mongo])
-                          ^DBObject (coerce-fields only)
-                          ^DBObject (coerce sort [from :mongo])
-                          remove?
-                          ^DBObject (coerce update [from :mongo])
-                          return-new? upsert?
-                          max-time-ms TimeUnit/MILLISECONDS) [:mongo as]))
+  [coll where update & {:as params}]
+  (let [{:keys [only sort remove? return-new? upsert? from as max-time-ms]}
+        (merge {:only nil :sort nil :remove? false
+                :return-new? false :upsert? false
+                :max-time-ms 0 :from :clojure :as :clojure}
+               *default-query-options*
+               params)]
+      (coerce (.findAndModify ^DBCollection (get-coll coll)
+                              ^DBObject (coerce where [from :mongo])
+                              ^DBObject (coerce-fields only)
+                              ^DBObject (coerce sort [from :mongo])
+                              remove?
+                              ^DBObject (coerce update [from :mongo])
+                              return-new? upsert?
+                              max-time-ms TimeUnit/MILLISECONDS) [:mongo as])))
 
 
 (defn destroy!

--- a/src/somnium/congomongo/config.clj
+++ b/src/somnium/congomongo/config.clj
@@ -21,3 +21,4 @@
 (ns somnium.congomongo.config)
 
 (def ^{:dynamic true} *mongo-config* {})
+(def ^{:dynamic true} *default-query-options* {})


### PR DESCRIPTION
In order to be able to specify default timeouts (and maybe other options in the future) for all queries rather than specify it in each fetch.