### PR TITLE
Update to reference clojars-publish context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ workflows:
     jobs:
       - test
       - release:
+          context: clojars-publish
           requires: [test]
           filters:
             branches:


### PR DESCRIPTION
The current configuration does not specify the `clojars-publish` context so any jar publish will be done using the LEIN_USERNAME environment variable.

This change assigns the context so that we can then remove the explicit reference to LEIN_USERNAME and LEIN_PASSWORD, this is part of a SecOps review of the Clojars user list -- https://circleci.atlassian.net/browse/SECOPS-28

The impetus for this change is to remove specific engineer credentials from the publish flow and also to shift from specific project configurations to a global context.

No code impact is expected and the referenced context has been used to push to Clojars already so it should not generate any errors.